### PR TITLE
Removed overflow issues

### DIFF
--- a/practice/sqrt_bs.cpp
+++ b/practice/sqrt_bs.cpp
@@ -1,6 +1,7 @@
+// Binary Search
+
 #include <bits/stdc++.h>
-#define ll long long int
-#define mod 1000000007
+
 using namespace std;
 
 int bs(int low, int high, int key)
@@ -8,8 +9,10 @@ int bs(int low, int high, int key)
 
     while (low <= high)
     {
-        int mid = (low + high) / 2;
+        int mid = (low + ((high - low) / 2)); // Overflow doesn't happen
+
         cout << mid << endl;
+
         if (mid * mid == key)
         {
             return mid;


### PR DESCRIPTION
The original author used this method to find the middle element `mid = (low + high) / 2`
which can lead to integer overflow problems.
So i changed this to: `mid = low + (high - low) / 2`